### PR TITLE
fix: adding a validation to avoid an store extension duplication

### DIFF
--- a/vue-sso.js
+++ b/vue-sso.js
@@ -40,6 +40,13 @@ export function createPhillyAccountPlugin(config) {
       return;
     }
 
+    // store id must include the word auth
+    if (!store.$id.toLowerCase().includes("auth")) {
+      return;
+    }
+
+    if (config.debug) console.log("Connecting to store: ", store.$id);
+
     let clientInfoObject = {};
     let customPostbackObject = {};
 
@@ -545,7 +552,7 @@ export function createPhillyAccountPlugin(config) {
                   throw Error(error);
                 }
               }
-              this.setSigningIn = false;
+              this.signingIn = false;
             }
           }
 
@@ -561,8 +568,8 @@ export function createPhillyAccountPlugin(config) {
 
     store.configMSALObject(config);
 
-    if (!config.dontHandleRedirectAutomatically) {
-      store.handleRedirect();
-    }
+    // if (!config.dontHandleRedirectAutomatically) {
+    //   store.handleRedirect();
+    // }
   };
 }

--- a/vue-sso.js
+++ b/vue-sso.js
@@ -568,8 +568,8 @@ export function createPhillyAccountPlugin(config) {
 
     store.configMSALObject(config);
 
-    // if (!config.dontHandleRedirectAutomatically) {
-    //   store.handleRedirect();
-    // }
+    if (!config.dontHandleRedirectAutomatically) {
+      store.handleRedirect();
+    }
   };
 }


### PR DESCRIPTION
From now on, if someone wants to use this library, they must create an store with the word 'auth' in it